### PR TITLE
Added GetKnownExtensions

### DIFF
--- a/src/MimeTypeMapTest/Program.cs
+++ b/src/MimeTypeMapTest/Program.cs
@@ -3,12 +3,15 @@ using MimeTypes;
 
 namespace MimeTypeMapTest
 {
-    class Program
+    internal class Program
     {
-        static void Main()
+        private static void Main()
         {
             Console.WriteLine("txt -> " + MimeTypeMap.GetMimeType("txt"));
             Console.WriteLine("audio/wav -> " + MimeTypeMap.GetExtension("audio/wav"));
+            Console.WriteLine("Extensions with text/plain mime type: " + string.Join(", ", MimeTypeMap.GetKnownExtensions("text/plain")));
+
+            Console.ReadKey();
         }
     }
 }

--- a/src/MimeTypes/MimeTypeMap.cs
+++ b/src/MimeTypes/MimeTypeMap.cs
@@ -6,13 +6,14 @@ namespace MimeTypes
 {
     public static class MimeTypeMap
     {
-        private static readonly Lazy<IDictionary<string, string>> _mappings = new Lazy<IDictionary<string, string>>(BuildMappings);
-            
-        private static IDictionary<string, string> BuildMappings() {
-            var mappings = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase) {
+        private static readonly Lazy<IDictionary<string, string>> Mappings = new Lazy<IDictionary<string, string>>(BuildMappings);
 
+        private static IDictionary<string, string> BuildMappings()
+        {
+            var mappings = new Dictionary<string, string>(StringComparer.InvariantCultureIgnoreCase)
+            {
                 #region Big freaking list of mime types
-            
+
                 // maps both ways,
                 // extension -> mime type
                 //   and
@@ -612,7 +613,6 @@ namespace MimeTypes
                 {".xwd", "image/x-xwindowdump"},
                 {".z", "application/x-compress"},
                 {".zip", "application/zip"},
-
                 {"application/fsharp-script", ".fsx"},
                 {"application/msaccess", ".adp"},
                 {"application/msword", ".doc"},
@@ -627,7 +627,7 @@ namespace MimeTypes
                 {"application/x-shockwave-flash", ".swf"},
                 {"application/x-x509-ca-cert", ".cer"},
                 {"application/xhtml+xml", ".xhtml"},
-                {"application/xml", ".xml"},  // anomoly, .xml -> text/xml, but application/xml -> many thingss, but all are xml, so safest is .xml
+                {"application/xml", ".xml"}, // anomoly, .xml -> text/xml, but application/xml -> many thingss, but all are xml, so safest is .xml
                 {"audio/aac", ".AAC"},
                 {"audio/aiff", ".aiff"},
                 {"audio/basic", ".snd"},
@@ -657,15 +657,14 @@ namespace MimeTypes
                 {"video/x-dv", ".dv"},
                 {"video/x-la-asf", ".lsf"},
                 {"video/x-ms-asf", ".asf"},
-                {"x-world/x-vrml", ".xof"},
+                {"x-world/x-vrml", ".xof"}
 
                 #endregion
-
-                };
+            };
 
             var cache = mappings.ToList(); // need ToList() to avoid modifying while still enumerating
 
-            foreach (var mapping in cache) 
+            foreach (var mapping in cache)
             {
                 if (!mappings.ContainsKey(mapping.Value))
                 {
@@ -690,7 +689,7 @@ namespace MimeTypes
 
             string mime;
 
-            return _mappings.Value.TryGetValue(extension, out mime) ? mime : "application/octet-stream";
+            return Mappings.Value.TryGetValue(extension, out mime) ? mime : "application/octet-stream";
         }
 
         public static string GetExtension(string mimeType)
@@ -707,12 +706,27 @@ namespace MimeTypes
 
             string extension;
 
-            if (_mappings.Value.TryGetValue(mimeType, out extension))
+            if (Mappings.Value.TryGetValue(mimeType, out extension))
             {
                 return extension;
             }
 
             throw new ArgumentException("Requested mime type is not registered: " + mimeType);
+        }
+
+        public static IEnumerable<string> GetKnownExtensions(string mimeType)
+        {
+            if (mimeType == null)
+            {
+                throw new ArgumentNullException("mimeType");
+            }
+
+            if (mimeType.StartsWith("."))
+            {
+                throw new ArgumentException("Requested mime type is not valid: " + mimeType);
+            }
+
+            return Mappings.Value.Where(s => s.Value.Equals(mimeType, StringComparison.InvariantCultureIgnoreCase)).Select(s => s.Key);
         }
     }
 }


### PR DESCRIPTION
Added GetKnownExtensions, which returns all the extensions which have the given mime type.

-PS: I know you do not approve of me renaming _mappings to Mappings, but that is the standard naming convention for readonly properties, although you can change it back if you want