### PR TITLE
Added x-zip-compressed to reverse index

### DIFF
--- a/src/MimeTypes/MimeTypeMap.cs
+++ b/src/MimeTypes/MimeTypeMap.cs
@@ -626,6 +626,7 @@ namespace MimeTypes
                 {"application/x-director", ".dir"},
                 {"application/x-shockwave-flash", ".swf"},
                 {"application/x-x509-ca-cert", ".cer"},
+                {"application/x-zip-compressed", ".zip"}
                 {"application/xhtml+xml", ".xhtml"},
                 {"application/xml", ".xml"},  // anomoly, .xml -> text/xml, but application/xml -> many thingss, but all are xml, so safest is .xml
                 {"audio/aac", ".AAC"},

--- a/src/MimeTypes/MimeTypeMap.cs
+++ b/src/MimeTypes/MimeTypeMap.cs
@@ -626,7 +626,7 @@ namespace MimeTypes
                 {"application/x-director", ".dir"},
                 {"application/x-shockwave-flash", ".swf"},
                 {"application/x-x509-ca-cert", ".cer"},
-                {"application/x-zip-compressed", ".zip"}
+                {"application/x-zip-compressed", ".zip"},
                 {"application/xhtml+xml", ".xhtml"},
                 {"application/xml", ".xml"},  // anomoly, .xml -> text/xml, but application/xml -> many thingss, but all are xml, so safest is .xml
                 {"audio/aac", ".AAC"},


### PR DESCRIPTION
Applications like Google Chrome use "application/x-zip-compressed" as the mimetype for .zip files, so it should be in the reverse index.