### PR TITLE
C# 6 syntax, add & replace methods

### DIFF
--- a/src/MimeTypeMapTest/MimeTypeMapTest.csproj
+++ b/src/MimeTypeMapTest/MimeTypeMapTest.csproj
@@ -10,8 +10,9 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>MimeTypeMapTest</RootNamespace>
     <AssemblyName>MimeTypeMapTest</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Client</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkProfile>
+    </TargetFrameworkProfile>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
@@ -23,6 +24,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
     <PlatformTarget>x86</PlatformTarget>
@@ -32,6 +34,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -47,8 +50,11 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
+  </ItemGroup>
+  <ItemGroup>
     <ProjectReference Include="..\MimeTypes\MimeTypes.csproj">
-      <Project>{D54FB6F6-9042-4925-BFC5-947A363F0849}</Project>
+      <Project>{d54fb6f6-9042-4925-bfc5-947a363f0849}</Project>
       <Name>MimeTypes</Name>
     </ProjectReference>
   </ItemGroup>

--- a/src/MimeTypeMapTest/Program.cs
+++ b/src/MimeTypeMapTest/Program.cs
@@ -9,6 +9,8 @@ namespace MimeTypeMapTest
         {
             Console.WriteLine("txt -> " + MimeTypeMap.GetMimeType("txt"));
             Console.WriteLine("audio/wav -> " + MimeTypeMap.GetExtension("audio/wav"));
+
+            MimeTypeMap.Replace("txt", "application/txt");
         }
     }
 }

--- a/src/MimeTypeMapTest/Program.cs
+++ b/src/MimeTypeMapTest/Program.cs
@@ -9,8 +9,14 @@ namespace MimeTypeMapTest
         {
             Console.WriteLine("txt -> " + MimeTypeMap.GetMimeType("txt"));
             Console.WriteLine("audio/wav -> " + MimeTypeMap.GetExtension("audio/wav"));
-
             MimeTypeMap.Replace("txt", "application/txt");
+            Console.WriteLine("txt -> " + MimeTypeMap.GetMimeType("txt"));
+            MimeTypeMap.Add("bigtext", "application/bigtext");
+            Console.WriteLine("bigtext MimeType -> " + MimeTypeMap.GetMimeType("bigtext"));
+            Console.WriteLine("bigtext Extension -> " + MimeTypeMap.GetExtension("application/bigtext"));
+            MimeTypeMap.Replace("bigtext", "application/mybigtext");
+            Console.WriteLine("bigtext replace -> " + MimeTypeMap.GetMimeType("bigtext"));
+            Console.ReadKey();
         }
     }
 }

--- a/src/MimeTypeMapTest/app.config
+++ b/src/MimeTypeMapTest/app.config
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5"/></startup></configuration>

--- a/src/MimeTypes/MimeTypeMap.cs
+++ b/src/MimeTypes/MimeTypeMap.cs
@@ -691,33 +691,92 @@ namespace MimeTypes
             return mappings;
         }
 
-        public static string GetMimeType(string extension)
+        public static void Add(string extension, string mimeType)
         {
-            if (extension == null)
-            {
-                throw new ArgumentNullException("extension");
-            }
+            if (string.IsNullOrWhiteSpace(extension))
+                throw new ArgumentNullException(nameof(extension));
 
-            if (!extension.StartsWith("."))
+            if (string.IsNullOrWhiteSpace(mimeType))
+                throw new ArgumentNullException(nameof(mimeType));
+
+            if ('.' != extension[0])
             {
-                extension = "." + extension;
+                extension = $".{extension}";
             }
 
             string mime;
+            if (_mappings.Value.TryGetValue(extension, out mime))
+            {
+                throw new ArgumentException($"Extension {extension} is already registered to {mime}.");
+            }
 
+            if ('.' == mimeType[0])
+            {
+                throw new ArgumentException($"Requested mime type is not valid: {mimeType}", nameof(mimeType));
+            }
+
+            _mappings.Value[extension] = mimeType;
+
+            if (!_mappings.Value.ContainsKey(mimeType))
+                _mappings.Value.Add(mimeType, extension);
+        }
+
+        public static void Replace(string extension, string mimeType)
+        {
+            if (string.IsNullOrWhiteSpace(extension))
+                throw new ArgumentNullException(nameof(extension));
+
+            if (string.IsNullOrWhiteSpace(mimeType))
+                throw new ArgumentNullException(nameof(mimeType));
+
+            if ('.' != extension[0])
+            {
+                extension = $".{extension}";
+            }
+            if ('.' == mimeType[0])
+            {
+                throw new ArgumentException($"Requested mime type is not valid: {mimeType}", nameof(mimeType));
+            }
+
+            string mime;
+            if (!_mappings.Value.TryGetValue(extension, out mime))
+            {
+                Add(extension, mimeType);
+            }
+            else
+            {
+                _mappings.Value[extension] = mimeType;
+                _mappings.Value[mimeType] = extension;
+            }
+
+            
+        }
+
+        public static string GetMimeType(string extension)
+        {
+            if (string.IsNullOrWhiteSpace(extension))
+            {
+                throw new ArgumentNullException(nameof(extension));
+            }
+
+            if ('.' != extension[0])
+            {
+                extension = $".{extension}";
+            }
+            string mime;
             return _mappings.Value.TryGetValue(extension, out mime) ? mime : "application/octet-stream";
         }
 
         public static string GetExtension(string mimeType)
         {
-            if (mimeType == null)
+            if (string.IsNullOrWhiteSpace(mimeType))
             {
-                throw new ArgumentNullException("mimeType");
+                throw new ArgumentNullException(nameof(mimeType));
             }
 
-            if (mimeType.StartsWith("."))
+            if ('.' == mimeType[0])
             {
-                throw new ArgumentException("Requested mime type is not valid: " + mimeType);
+                throw new ArgumentException($"Requested mime type is not valid: {mimeType}", nameof(mimeType));
             }
 
             string extension;
@@ -727,7 +786,7 @@ namespace MimeTypes
                 return extension;
             }
 
-            throw new ArgumentException("Requested mime type is not registered: " + mimeType);
+            throw new ArgumentException($"Requested mime type is not registered: {mimeType}", nameof(mimeType));
         }
     }
 }


### PR DESCRIPTION
Hello,

Not sure if this is helpful to the main code repository however I have upgrade the syntax to c# 6 and added in Add\Replace methods so it can be managed without recompiling.

Usage:
```
Console.WriteLine("txt -> " + MimeTypeMap.GetMimeType("txt"));
Console.WriteLine("audio/wav -> " + MimeTypeMap.GetExtension("audio/wav"));
MimeTypeMap.Replace("txt", "application/txt");
Console.WriteLine("txt -> " + MimeTypeMap.GetMimeType("txt"));
MimeTypeMap.Add("bigtext", "application/bigtext");
Console.WriteLine("bigtext MimeType -> " + MimeTypeMap.GetMimeType("bigtext"));
Console.WriteLine("bigtext Extension -> " + MimeTypeMap.GetExtension("application/bigtext"));
MimeTypeMap.Replace("bigtext", "application/mybigtext");
Console.WriteLine("bigtext replace -> " + MimeTypeMap.GetMimeType("bigtext"));
Console.ReadKey();
```