### PR TITLE
Extended the logic for GetMimeType & GetExtension

### DIFF
--- a/src/MimeTypes/MimeTypeMap.cs
+++ b/src/MimeTypes/MimeTypeMap.cs
@@ -694,7 +694,7 @@ namespace MimeTypes
             return mappings;
         }
 
-        public static string GetMimeType(string extension)
+        public static string GetMimeType(string extension, string defaultIfNotFound = "application/octet-stream")
         {
             if (extension == null)
             {
@@ -706,12 +706,26 @@ namespace MimeTypes
                 extension = "." + extension;
             }
 
-            string mime;
+            string mimeType;
 
-            return _mappings.Value.TryGetValue(extension, out mime) ? mime : "application/octet-stream";
+            if (_mappings.Value.TryGetValue(extension, out mimeType))
+            {
+                return mimeType;
+            }
+            else
+            {
+                if (string.IsNullOrEmpty(defaultIfNotFound))
+                {
+                    throw new ArgumentException("Requested extension is not registered: " + extension);
+                }
+                else
+                {
+                    return defaultIfNotFound;
+                }
+            }
         }
 
-        public static string GetExtension(string mimeType)
+        public static string GetExtension(string mimeType, string defaultIfNotFound = null)
         {
             if (mimeType == null)
             {
@@ -729,8 +743,17 @@ namespace MimeTypes
             {
                 return extension;
             }
-
-            throw new ArgumentException("Requested mime type is not registered: " + mimeType);
+            else
+            {
+                if (string.IsNullOrEmpty(defaultIfNotFound))
+                {
+                    throw new ArgumentException("Requested mime type is not registered: " + mimeType);
+                }
+                else
+                {
+                    return defaultIfNotFound;
+                }
+            }            
         }
     }
 }

--- a/src/MimeTypes/Properties/AssemblyInfo.cs
+++ b/src/MimeTypes/Properties/AssemblyInfo.cs
@@ -32,4 +32,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.0.0")]
+[assembly: AssemblyVersion("2.4.0.0")]


### PR DESCRIPTION
Added optional parameter defaultIfNotFound, if value wasn't found in dictionaty, then default value will be used. If defaultValue is null or empty, then it will throw ArgumentException.