### PR TITLE
Added Licence Text to the file header

### DIFF
--- a/src/MimeTypes/MimeTypeMap.cs
+++ b/src/MimeTypes/MimeTypeMap.cs
@@ -1,4 +1,27 @@
-﻿using System;
+﻿// <copyright file="MimeTypeMap.cs">
+// Copyright(c) 2014 Samuel Neff
+// 
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+// 
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+// </copyright>
+// <author>Samuel Neff & Contributors</author>
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 


### PR DESCRIPTION
This is important for those that want to include this file in their own project because MIT states that the LICENCE should be written somewhere. So this is only for convenience for those that copy this file in their own sources