### PR TITLE
Add Support for .NET Core 2.0 and Standard 2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 *.sln.docstates
+**/*.vs/*
 
 # Build results
 [Dd]ebug/

--- a/README.md
+++ b/README.md
@@ -57,6 +57,8 @@ Pass in a mime type and get an extension back. If the mime type is not registere
 
 ## Changelog
 
+2.3.2.0 - December, 28 2017 - Add Support for .NET Standard 2.0 and .NET Core 2.0
+
 2.1.0 - August 14, 2015 - Refactor and add GetExtension method.
 
 1.2.0 - April 22, 2015 - Breaking changes due to refactorings. You'll need to change namespace after this update. Also added OpenOffice related mime types, in a few cases overwriting rarely used MS mime types for the same extensions.

--- a/src/MimeTypes/MimeTypes.csproj
+++ b/src/MimeTypes/MimeTypes.csproj
@@ -1,50 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
-    <MinimumVisualStudioVersion>10.0</MinimumVisualStudioVersion>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{D54FB6F6-9042-4925-BFC5-947A363F0849}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>MimeTypes</RootNamespace>
-    <AssemblyName>MimeTypes</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFrameworkProfile>Profile111</TargetFrameworkProfile>
-    <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
+    <TargetFrameworks>net45;netcoreapp2.0;netstandard2.0;</TargetFrameworks>
+    <PackageId>MimeTypeMap</PackageId>
+    <Version>1.0.3</Version>
+    <Authors>Samuel Neff</Authors>
+    <Company>Samuel Neff</Company>
+    <Product>MimeTypeMap</Product>
+    <PackageProjectUrl>https://github.com/samuelneff/MimeTypeMap</PackageProjectUrl>
+    <PackageLicenseUrl>https://github.com/samuelneff/MimeTypeMap/blob/master/LICENSE</PackageLicenseUrl>
+    <Copyright>Samuel Neff 2017</Copyright>
+    <PackageTags>C# ASP.NET</PackageTags>
+    <Description>Huge dictionary of file extensions to mime types</Description>
+    <AssemblyVersion>2.3.2.0</AssemblyVersion>
+    <FileVersion>2.3.2.0</FileVersion>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-  </PropertyGroup>
-  <ItemGroup>
-    <Compile Include="MimeTypeMap.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+
+
 </Project>

--- a/src/MimeTypes/Properties/AssemblyInfo.cs
+++ b/src/MimeTypes/Properties/AssemblyInfo.cs
@@ -1,16 +1,9 @@
 ﻿using System.Reflection;
-using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
 // General Information about an assembly is controlled through the following 
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("MimeTypeMap")]
-[assembly: AssemblyDescription("Huge dictionary of file extensions to mime types")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("Samuel Neff")]
-[assembly: AssemblyProduct("MimeTypeMap")]
-[assembly: AssemblyCopyright("Copyright ©  2014")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
@@ -32,4 +25,4 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.3.1.0")]
+//[assembly: AssemblyVersion("2.3.1.0")]


### PR DESCRIPTION
Hi Samuel,

I am in the process of converting a project to .NET core so that I can run it cross platform and as a docker container. The only nuget that does not support .NET core is MimeTypeMap, so I have gone a head and converted it, in this pull request. 

This solves issue #53. 

It does not create a different solution and/or project file, because that is not necessary anymore. 

I have attached an updated Nuget file, if you don't have a current environment to create one. 

[MimeTypeMap.1.0.3.zip](https://github.com/samuelneff/MimeTypeMap/files/1592341/MimeTypeMap.1.0.3.zip)

Let me know if you have any questions or are looking for help maintaing this repo?

Thank you,
Jack
