### PR TITLE
Add .asmdef files for Unity3D compilation

### DIFF
--- a/src/MimeTypeMapTest/MimeTypeMaptest.asmdef
+++ b/src/MimeTypeMapTest/MimeTypeMaptest.asmdef
@@ -1,0 +1,12 @@
+{
+    "name": "MimeTypeMaptest",
+    "references": [
+        "MimeTypes"
+    ],
+    "optionalUnityReferences": [
+        "TestAssemblies"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false
+}

--- a/src/MimeTypes/MimeTypes.asmdef
+++ b/src/MimeTypes/MimeTypes.asmdef
@@ -1,0 +1,8 @@
+{
+    "name": "MimeTypes",
+    "references": [],
+    "optionalUnityReferences": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false
+}


### PR DESCRIPTION
When using `AssemblyInfo.cs` files with Unity3D, each package having such a file needs to have a separate `.asmdef` Assembly Definition file so that the Unity C# compiler knows where the packages begin and end.  Otherwise it will complain about having multiple assembly definitions for e.g. GUID.

This pull request adds simple `.asmdef` files to facilitate using MimeTypeMap with Unity3D.
