### PR TITLE
Support for image/x-png

### DIFF
--- a/src/MimeTypes/MimeTypeMap.cs
+++ b/src/MimeTypes/MimeTypeMap.cs
@@ -670,7 +670,8 @@ namespace MimeTypes
                 {"image/bmp", ".bmp"},
                 {"image/jpeg", ".jpg"},
                 {"image/pict", ".pic"},
-                {"image/png", ".png"},
+                {"image/png", ".png"}, //Defined in [RFC-2045], [RFC-2048]
+                {"image/x-png", ".png"}, //See https://www.w3.org/TR/PNG/#A-Media-type :"It is recommended that implementations also recognize the media type "image/x-png"."
                 {"image/tiff", ".tiff"},
                 {"image/x-macpaint", ".mac"},
                 {"image/x-quicktime", ".qti"},


### PR DESCRIPTION
Adding support for mime type "image/x-png" as recommended by [Portable Network Graphics (PNG): Functional specification. ISO/IEC 15948:2003](https://www.w3.org/TR/PNG/#A-Media-type)

From the w3 Spec:
> The internet media type "image/png" is the Internet Media Type for PNG [RFC-2045], [RFC-2048]. It is **recommended that implementations also recognize the media type "image/x-png"**.