### PR TITLE
"application/x-czx" for ".czx" extension

### DIFF
--- a/MimeTypeMap.cs
+++ b/MimeTypeMap.cs
@@ -129,6 +129,7 @@ namespace MimeTypes
                 {".css", "text/css"},
                 {".csv", "text/csv"},
                 {".cur", "application/octet-stream"},
+                {".czx", "application/x-czx"},
                 {".cxx", "text/plain"},
                 {".dat", "application/octet-stream"},
                 {".datasource", "application/xml"},


### PR DESCRIPTION
Added mime type "application/x-czx" for ".czx" file extension which is used in CZIP X application