### PR TITLE
Added check to see if string contains a question mark

### DIFF
--- a/MimeTypeMap.cs
+++ b/MimeTypeMap.cs
@@ -10,6 +10,7 @@ namespace MimeTypes
     public static class MimeTypeMap
     {
         private const string Dot = ".";
+        private const string QuestionMark = "?";
         private const string DefaultMimeType = "application/octet-stream";
         private static readonly Lazy<IDictionary<string, string>> _mappings = new Lazy<IDictionary<string, string>>(BuildMappings);
 
@@ -759,6 +760,11 @@ namespace MimeTypes
                 }
 
                 str = Dot + str;
+            }
+
+            if (str.Contains(QuestionMark))
+            {
+                str = str.Remove(str.IndexOf(QuestionMark, StringComparison.Ordinal));
             }
 
             return _mappings.Value.TryGetValue(str, out mimeType);

--- a/MimeTypeMap.cs
+++ b/MimeTypeMap.cs
@@ -762,9 +762,10 @@ namespace MimeTypes
                 str = Dot + str;
             }
 
-            if (str.Contains(QuestionMark))
+            var indexQuestionMark = str.IndexOf(QuestionMark, StringComparison.Ordinal);
+            if (indexQuestionMark != -1)
             {
-                str = str.Remove(str.IndexOf(QuestionMark, StringComparison.Ordinal));
+                str = str.Remove(indexQuestionMark);
             }
 
             return _mappings.Value.TryGetValue(str, out mimeType);


### PR DESCRIPTION
Basically, if I'm trying to save a file from a URL, there may be query parameters after the file extension. So, we need to remove the query parameters so that we can get a valid file extension & mime type. Since question marks aren't allowed in file names or extensions, I figured it was unnecessary to do any further validations (like if the string was a URL or not). 