### PR TITLE
Added net40 TFM to also support lower versions of .NET

### DIFF
--- a/MimeTypes.csproj
+++ b/MimeTypes.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net452;net48;netcoreapp2.2;netcoreapp3.1;netstandard2.0;</TargetFrameworks>
+    <TargetFrameworks>net40;net452;net48;netcoreapp2.2;netcoreapp3.1;netstandard2.0;</TargetFrameworks>
     <PackageId>MimeTypeMapOfficial</PackageId>
     <Version>1.0.15</Version>
     <Authors>Samuel Neff</Authors>


### PR DESCRIPTION
I wanted to use this mime type map in my WPF applications but they are currently target .net45. So I added the .net40 target framework to support lower versions of .NET without any assembly bindings (from .NET Standard).