### PR TITLE
Fixed jpg Issue

### DIFF
--- a/MimeTypeMap.cs
+++ b/MimeTypeMap.cs
@@ -266,7 +266,7 @@ namespace MimeTypes
                 {".jpb", "application/octet-stream"},
                 {".jpe", "image/jpeg"},
                 {".jpeg", "image/jpeg"},
-                {".jpg", "image/jpeg"},
+                {".jpg", "image/jpg"},
                 {".js", "application/javascript"},
                 {".json", "application/json"},
                 {".jsx", "text/jscript"},


### PR DESCRIPTION
MimeTypeMap.GetExtension("image/jpg") - throws an error when it shouldn't